### PR TITLE
Feature/scaling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: midr
 Type: Package
 Title: Learning from Black-Box Models by Maximum Interpretation Decomposition
-Version: 0.5.3
+Version: 0.5.3.900
 Authors@R: c(
     person("Ryoichi", "Asashiba", email = "ryoichi.asashiba@gmail.com",
            role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# midr 0.5.3.900
+
+-   Fixed incorrect calculation in `interpret()` when `singular.ok = TRUE` (or, more directly, `weighted.norm = TRUE`) and `lambda > 0`.
+-   Modified weights calculation to enhance the numerical stability.
+
 # midr 0.5.3
 
 Fourth release on CRAN. This version introduces significant memory efficiency improvements for large-scale data analysis.


### PR DESCRIPTION
version 0.5.3.900
- Normalized total weight to $N$ to improve the balance between numerical stability and centering constraints.
- Introduced the `nil` threshold for sparsity detection (`vnil`) to ensure robustness against floating-point errors.
- Fixed a scaling bug in the regularization term when `weighted.norm = TRUE` and `lambda > 0`.